### PR TITLE
Swift 4.0 Compatibility experimental fixing.

### DIFF
--- a/COpenSSL/include/module.modulemap
+++ b/COpenSSL/include/module.modulemap
@@ -2,6 +2,5 @@ module COpenSSL {
 	header "openssl.h"
 	link "crypto"
 	link "ssl"
-	link "COpenSSL"
 	export *
 }


### PR DESCRIPTION
The previous version of link “COpenSSL” in module.modulemap is no longer support in Swift 4.0. By removing this line, now COpenSSL-linux is compatible with both Swift 3.1.1 and Swift 4.0. Test performed on docker images “rockywei/swift:3.1” and “rockywei/swift:4.0”, which is using 8.27 snapshot of swift.