### PR TITLE
Expose x509v3.h

### DIFF
--- a/COpenSSL/include/openssl.h
+++ b/COpenSSL/include/openssl.h
@@ -2,6 +2,7 @@
 #include "openssl/ssl.h"
 #include "openssl/err.h"
 #include "openssl/x509.h"
+#include "openssl/x509v3.h"
 #include "openssl/sha.h"
 #include "openssl/bio.h"
 #include "openssl/hmac.h"


### PR DESCRIPTION
`x509v3.h` is referenced from several other C files in the code, but the functions and structures are not exposed.

In our project, specifically, we use the `GEN_EMAIL` constant and the `GENERAL_NAME` struct from `x509v3.h`